### PR TITLE
Fix heading in GCP commands reference

### DIFF
--- a/gcp_commands.md
+++ b/gcp_commands.md
@@ -1,4 +1,4 @@
-#GCP Command Reference
+# GCP Command Reference
 =====================
 
 These gcloud commands are used throughout the course:


### PR DESCRIPTION
## Summary
- correct spacing in the `gcp_commands.md` heading

## Testing
- `terraform init -backend=false` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857370e0acc8330bd7d52a152a86150